### PR TITLE
improve test suite

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -15,8 +15,8 @@ TESTS = {
             "answer": "1 January 2000 year 0 hours 0 minutes"
         },
         {
-            "input": "09.05.1945 06:30",
-            "answer": "9 May 1945 year 6 hours 30 minutes"
+            "input": "09.05.1945 06:07",
+            "answer": "9 May 1945 year 6 hours 7 minutes"
         }
     ],
     "Extra": [
@@ -25,8 +25,8 @@ TESTS = {
             "answer": "20 November 1990 year 3 hours 55 minutes"
         },
         {
-            "input": "09.07.1995 16:50",
-            "answer": "9 July 1995 year 16 hours 50 minutes"
+            "input": "09.07.1995 16:01",
+            "answer": "9 July 1995 year 16 hours 1 minute"
         },
 	{
             "input": "11.04.1812 01:01",


### PR DESCRIPTION
As you can see from https://py.checkio.org/mission/date-and-time-converter/publications/leggewie/python-3/second-bool-for-plural-s-and-f-string/ the current test suite is incomplete (I made a mistake in how I use s1 and s2, they need to be used the other way round).  Only two out of the four possibilities for hour/hours and minute/minutes combinations are tested.  

I've changed one more test to make sure that "7 minutes" is not accepted as "07 minutes".