### PR TITLE
Add a test for years between 0 and 1000

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -31,6 +31,10 @@ TESTS = {
 	{
             "input": "11.04.1812 01:01",
             "answer": "11 April 1812 year 1 hour 1 minute"
+        },
+	{
+            "input": "16.02.512 12:00",
+            "answer": "16 February 512 year 12 hours 0 minutes"
         }
     ]
 }


### PR DESCRIPTION
Hi, from the mission preconditions years could be "0 < year <= 3000". But until now years between 0 and 1000 were not tested and therefore I have seen solutions that will not work if the time sting doesn't include a year 4 characters long.